### PR TITLE
Fixup Auto Merge

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -8,7 +8,7 @@ permissions:
 jobs:
   dependabot:
     runs-on: ubuntu-latest
-    if: github.event.pull_request.user.login == 'dependabot[bot]' && github.repository == 'ie3-institute/simona'
+    if: github.event.pull_request.user.login == 'dependabot[bot]' && github.repository == 'ie3-institute/psdm2pp'
     steps:
       - name: Dependabot metadata
         id: metadata


### PR DESCRIPTION
Closes #32 
This pull request makes a targeted update to the Dependabot auto-merge workflow configuration. The change ensures that the workflow only runs for pull requests in the correct repository.

* Updated the `if` condition in `.github/workflows/dependabot-auto-merge.yml` to check for the `ie3-institute/psdm2pp` repository instead of `ie3-institute/simona`, ensuring the workflow is restricted to the intended project.